### PR TITLE
Be smarter about API URLs

### DIFF
--- a/gitlab-ci-lint
+++ b/gitlab-ci-lint
@@ -8,8 +8,17 @@ else
     INPUT=$(</dev/stdin)
 fi
 
+if [ "x$CI_API_V4_URL" != "x" ] ; then
+    # if we're running as a CI job, pick the provided API base url unless
+    # overridden
+    GITLAB_API_URL="${GITLAB_API_URL:-$CI_API_V4_URL}"
+else
+    # otherwise, use gitlab.com's API URL unless overridden
+    GITLAB_API_URL="${GITLAB_API_URL:-https://gitlab.com/api/v4}"
+fi
+
 CONTENT=$(echo "$INPUT" | yq '.' | tr -d '\n' | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-RESPONSE=$(curl --header "Content-Type: application/json" https://gitlab.com/api/v4/ci/lint --data @- <<CURL_DATA
+RESPONSE=$(curl --header "Content-Type: application/json" $GITLAB_API_URL/ci/lint --data @- <<CURL_DATA
 {"content": $CONTENT}
 CURL_DATA
 )


### PR DESCRIPTION
Generally speaking, we often just want gitlab.com.

However, if we're running under GitLab CI, it provides us with the URL
in `$CI_API_V4_URL`.  This will often be gitlab.com, but also makes
supporting standalone GitLab instances trivial.

In either case, the API url can be manually specified by setting
`$GITLAB_API_URL`.